### PR TITLE
Fix getting latest client library changes for build

### DIFF
--- a/bin/build_spec.sh
+++ b/bin/build_spec.sh
@@ -10,6 +10,8 @@ checkout_client_lib() (
 	dest="$2"
 
 	if [[ -d "$dest" ]]; then
+		cd $dest
+		echo "Getting latest changes for $dest"
 		git checkout master
 		git pull
         return


### PR DESCRIPTION
- Currently the bash script has a step that is supposed to pull the latest changes for each client library but instead it pulls latest changes for Asana/openapi. This fix will pull changes from the client libraries as it was intended.