### PR TITLE
[Secrets] Use the new secrets naming format for the push_openapi_spec_to_readme action

### DIFF
--- a/.github/workflows/push_openapi_spec_to_readme.yml
+++ b/.github/workflows/push_openapi_spec_to_readme.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Load secrets
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
-          secret-ids: README_API,prod/github_actions_push_openapi_spec_to_readme/readme_api_key
+          secret-ids: README_API,readme_api_key
           # readme_api_key secret is stored as {key:"***..."}.
           # GitHub Actions environment variable name is README_API so to access "key" from the json we can use README_API_KEY
           parse-json-secrets: true


### PR DESCRIPTION
### Summary

`prod/github_actions_push_openapi_spec_to_readme/readme_api_key` should be using the newer secret naming format here: just `readme_api_key`

Asana tasks:


Relevant deployment: 

CC: @jv-asana @harshita-gupta @darcysimmonsasana

### Test Plan

n/a?

### Risks


