### PR TITLE
resolve validation errors under OpenAPI 3.0

### DIFF
--- a/defs/app_components_oas.yaml
+++ b/defs/app_components_oas.yaml
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.0
+openapi: 3.0.4
 info:
   description: >-
     This is the interface for handling requests for
@@ -904,6 +904,18 @@ components:
                 [FormField-RichText](/reference/modal-forms#formfield-richtext), [FormField-SingleLineText](/reference/modal-forms#formfield-singlelinetext),
                 [FormField-StaticText](/reference/modal-forms#formfield-statictext), [FormField-Typeahead](/reference/modal-forms#formfield-typeahead)
               type: array
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/FormField-Checkbox'
+                  - $ref: '#/components/schemas/FormField-Date'
+                  - $ref: '#/components/schemas/FormField-Datetime'
+                  - $ref: '#/components/schemas/FormField-Dropdown'
+                  - $ref: '#/components/schemas/FormField-MultiLineText'
+                  - $ref: '#/components/schemas/FormField-RadioButton'
+                  - $ref: '#/components/schemas/FormField-RichText'
+                  - $ref: '#/components/schemas/FormField-SingleLineText'
+                  - $ref: '#/components/schemas/FormField-StaticText'
+                  - $ref: '#/components/schemas/FormField-Typeahead'
             on_submit_callback:
               description: >-
                 The URL to `POST` the form to when the user clicks the submit button.
@@ -1435,6 +1447,11 @@ components:
 
                 Valid object schemas: [WidgetField-DatetimeWithIcon](/reference/widgets#widgetfield-datetimewithicon), [WidgetField-Pill](/reference/widgets#widgetfield-pill), [WidgetField-TextWithIcon](/reference/widgets#widgetfield-textwithicon).
               type: array
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/DatetimeWithIcon'
+                  - $ref: '#/components/schemas/WidgetField-Pill'
+                  - $ref: '#/components/schemas/WidgetField-TextWithIcon'
             subtitle:
               description: >-
                 The text to show under the title of the widget, next to "Open in {App Name}". If not provided, the

--- a/defs/app_components_oas.yaml
+++ b/defs/app_components_oas.yaml
@@ -289,6 +289,7 @@ components:
           description: >-
             The label of the option. Limit 80 characters.
           type: string
+          maxLength: 80
           example: 'Opt in'
     DropdownOption:
       description: >-
@@ -307,6 +308,7 @@ components:
           description: >-
             The label of the option. Limit 80 characters.
           type: string
+          maxLength: 80
           example: 'Red'
         icon_url:
           description: >-
@@ -358,6 +360,7 @@ components:
           description: >-
             The text (i.e., label) for the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Please enter the following details:'
         style:
           description: >-
@@ -391,6 +394,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Resource name'
         is_required:
           description: >-
@@ -425,6 +429,7 @@ components:
           description: >-
             The value of the field. If not provided, the field will be empty and the form cannot be submitted if it is required. Limit 200 characters.
           type: string
+          maxLength: 200
           example: "Annual Kick-Off Meeting"
     FormField-MultiLineText:
       description: >-
@@ -450,6 +455,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Resource name'
         is_required:
           description: >-
@@ -476,6 +482,7 @@ components:
           description: >-
             The value of the field. If not provided, the field will be empty and the form cannot be submitted if it is required. Limit 3000 characters.
           type: string
+          maxLength: 3000
           example: "Annual Kick-Off Meeting"
     FormField-RichText:
       description: >-
@@ -501,6 +508,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Resource name'
         is_required:
           description: >-
@@ -527,6 +535,7 @@ components:
           description: >-
             The value of the field. If not provided, the field will be empty and the form cannot be submitted if it is required. Limit 3000 characters.
           type: string
+          maxLength: 3000
           example: "Annual Kick-Off Meeting"
     FormField-Dropdown:
       description: >-
@@ -536,6 +545,7 @@ components:
         - id
         - type
         - options
+      maxProperties: 50
       properties:
         type:
           description: >-
@@ -553,6 +563,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Resource name'
         is_required:
           description: >-
@@ -597,6 +608,7 @@ components:
         - id
         - type
         - options
+      maxProperties: 5
       properties:
         type:
           description: >-
@@ -614,6 +626,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Resource name'
         is_required:
           description: >-
@@ -650,6 +663,7 @@ components:
         - id
         - type
         - options
+      maxProperties: 10
       properties:
         type:
           description: >-
@@ -667,6 +681,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Resource name'
         is_required:
           description: >-
@@ -722,6 +737,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Date'
         is_required:
           description: >-
@@ -775,6 +791,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Datetime'
         is_required:
           description: >-
@@ -829,6 +846,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 50 characters.
           type: string
+          maxLength: 50
           example: 'Statuses'
         is_required:
           description: >-
@@ -904,6 +922,7 @@ components:
                 [FormField-RichText](/reference/modal-forms#formfield-richtext), [FormField-SingleLineText](/reference/modal-forms#formfield-singlelinetext),
                 [FormField-StaticText](/reference/modal-forms#formfield-statictext), [FormField-Typeahead](/reference/modal-forms#formfield-typeahead)
               type: array
+              maxItems: 30
               items:
                 anyOf:
                   - $ref: '#/components/schemas/FormField-Checkbox'
@@ -1187,6 +1206,7 @@ components:
           description: >-
             The label of the option. Limit 80 characters.
           type: string
+          maxLength: 80
           example: 'Radio Option 1'
         sub_label:
           description: >-
@@ -1320,6 +1340,7 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 40 characters.
           type: string
+          maxLength: 40
           example: 'Status'
         datetime:
           description: >-
@@ -1352,11 +1373,13 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 40 characters.
           type: string
+          maxLength: 40
           example: 'Status'
         text:
           description: >-
             The text to show in the field. Limit 40 characters.
           type: string
+          maxLength: 40
           example: 'In Progress'
         color:
           description: >-
@@ -1400,11 +1423,13 @@ components:
           description: >-
             The text (i.e., label) to show in the title of the field. Limit 40 characters.
           type: string
+          maxLength: 40
           example: 'Status'
         text:
           description: >-
             The text to show in the field. Limit 40 characters.
           type: string
+          maxLength: 40
           example: 'In Progress'
         icon_url:
           description: >-
@@ -1447,6 +1472,8 @@ components:
 
                 Valid object schemas: [WidgetField-DatetimeWithIcon](/reference/widgets#widgetfield-datetimewithicon), [WidgetField-Pill](/reference/widgets#widgetfield-pill), [WidgetField-TextWithIcon](/reference/widgets#widgetfield-textwithicon).
               type: array
+              minItems: 1
+              maxItems: 5
               items:
                 anyOf:
                   - $ref: '#/components/schemas/DatetimeWithIcon'

--- a/defs/asana_sdk_oas.yaml
+++ b/defs/asana_sdk_oas.yaml
@@ -1,5 +1,5 @@
 ---
-openapi: 3.0.0
+openapi: 3.0.4
 info:
   description: >-
     This is the interface for interacting with the [Asana
@@ -1573,391 +1573,469 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
     AccessRequestResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AccessRequestResponseArray'
     AccessRequestResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AccessRequestResponseData'
     EmptyResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/EmptyResponseData'
     AllocationResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AllocationResponseData'
     AllocationResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AllocationResponseArray'
     AttachmentResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AttachmentResponseData'
     AttachmentResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AttachmentResponseArray'
     AuditLogEventArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AuditLogEventArray'
     BatchResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/BatchResponseArray'
     BudgetResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/BudgetResponseArray'
     BudgetResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/BudgetResponseData'
     CustomFieldSettingResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/CustomFieldSettingResponseArray'
     CustomFieldResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/CustomFieldResponseData'
     CustomFieldResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/CustomFieldResponseArray'
     EnumOptionData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/EnumOptionData'
     CustomTypeResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/CustomTypeResponseArray'
     CustomTypeResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/CustomTypeResponseData'
     EventResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/EventResponseArray'
     GraphExportResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/GraphExportResponseData'
     ResourceExportResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ResourceExportResponseData'
     GoalRelationshipResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/GoalRelationshipResponseData'
     GoalRelationshipResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/GoalRelationshipResponseArray'
     GoalResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/GoalResponseData'
     GoalResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/GoalResponseArray'
     CustomFieldSettingResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/CustomFieldSettingResponseData'
     JobResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/JobResponseData'
     MembershipResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/MembershipResponseArray'
     MembershipResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/MembershipResponseData'
     OrganizationExportResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/OrganizationExportResponseData'
     DeprecatedPortfolioMembershipResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/DeprecatedPortfolioMembershipResponseArray'
     DeprecatedPortfolioMembershipResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/DeprecatedPortfolioMembershipResponseData'
     PortfolioResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/PortfolioResponseArray'
     PortfolioResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/PortfolioResponseData'
     ProjectResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectResponseArray'
     ProjectBriefResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectBriefResponseData'
     ProjectMembershipNormalResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectMembershipNormalResponseData'
     ProjectMembershipCompactArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectMembershipCompactArray'
     ProjectStatusResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectStatusResponseData'
     ProjectStatusResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectStatusResponseArray'
     ProjectTemplateResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectTemplateResponseData'
     ProjectTemplateResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectTemplateResponseArray'
     ProjectResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ProjectResponseData'
     TaskCountResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TaskCountResponseData'
     RateOrPlaceholderCompactArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/RateOrPlaceholderCompactArray'
     RateResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/RateResponseData'
     ReactionCompactArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/ReactionCompactArray'
     RuleTriggerResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/RuleTriggerResponseData'
     SectionResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/SectionResponseData'
     SectionResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/SectionResponseArray'
     StatusUpdateResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/StatusUpdateResponseData'
     StatusUpdateResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/StatusUpdateResponseArray'
     StoryResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/StoryResponseData'
     StoryResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/StoryResponseArray'
     TagResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TagResponseArray'
     TagResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TagResponseData'
     TaskTemplateResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TaskTemplateResponseArray'
     TaskTemplateResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TaskTemplateResponseData'
     TaskResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TaskResponseArray'
     TaskResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TaskResponseData'
     TeamMembershipResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TeamMembershipResponseData'
     TeamMembershipResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TeamMembershipResponseArray'
     TeamResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TeamResponseData'
     TeamResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TeamResponseArray'
     TimePeriodResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TimePeriodResponseData'
     TimePeriodResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TimePeriodResponseArray'
     TimeTrackingEntryCompactArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TimeTrackingEntryCompactArray'
     TimeTrackingEntryBaseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/TimeTrackingEntryBaseData'
     AsanaNamedResourceArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/AsanaNamedResourceArray'
     UserTaskListResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/UserTaskListResponseData'
     UserResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/UserResponseArray'
     UserResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/UserResponseData'
     WebhookResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/WebhookResponseArray'
     WebhookResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/WebhookResponseData'
     WorkspaceMembershipResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/WorkspaceMembershipResponseData'
     WorkspaceMembershipResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/WorkspaceMembershipResponseArray'
     WorkspaceResponseArray:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/WorkspaceResponseArray'
     WorkspaceResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:
             $ref: '#/components/schemas/WorkspaceResponseData'
     UserBaseResponseData:
+      description: ''
       content:
         application/json; charset=UTF-8:
           schema:


### PR DESCRIPTION
specifically:
- "items" must be present if type is "array"
- "description" must be present in a responses object

You may also want to move your documents to OpenAPI 3.2, which has looser constraints on these keywords.